### PR TITLE
This change allows me to install your gem.

### DIFF
--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -1,7 +1,7 @@
 __LIB_DIR__ = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift __LIB_DIR__ unless $LOAD_PATH.include?(__LIB_DIR__)
 
-require 'active_support/all'
+require 'activesupport/all'
 require 'json'
 require 'net/http'
 require 'net/https'


### PR DESCRIPTION
Re: http://help.rubygems.org/discussions/suggestions/2747-please-remove-the-active_support-gem

Otherwise I get all sorts of errors:

```
Could not find gem 'active_support (>= 0) ruby', which is required by gem 'lita-pagerduty (>= 0) ruby'
```
