### PR TITLE
Revert "This change allows me to install your gem."

### DIFF
--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -1,7 +1,7 @@
 __LIB_DIR__ = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift __LIB_DIR__ unless $LOAD_PATH.include?(__LIB_DIR__)
 
-require 'activesupport/all'
+require 'active_support/all'
 require 'json'
 require 'net/http'
 require 'net/https'


### PR DESCRIPTION
Please revert.

I think the problem I'm having is because the gem that's currently pushed refers to "active_support" as the gem name.

Bump to 1.0.6, rebuild what you have and push - all should be well.
