### PR TITLE
Include the description field in TriggerSummaryData

### DIFF
--- a/lib/pagerduty/models/triggersummarydata.rb
+++ b/lib/pagerduty/models/triggersummarydata.rb
@@ -2,5 +2,6 @@ class TriggerSummaryData
   include Virtus.model
 
   attribute :subject
+  attribute :description
 end
 


### PR DESCRIPTION
The trigger summary data can have a lot of different formats to it. When
the event API is used to trigger an incident it has a "description"
field but not a "subject" field. When nagios triggers an incident it has
a "subject" field but not a "description" field.

In order to keep with the model of this library, this adds another field
rather than trying to combine the fields together. A user can decide
which of the fields to use rather then the library trying to decide.
